### PR TITLE
allow customizing default headers

### DIFF
--- a/efrit-agent.el
+++ b/efrit-agent.el
@@ -79,6 +79,7 @@
 (condition-case nil
 (progn
 (require 'efrit-tools)
+(require 'efrit-chat)
 (require 'project nil t))
 (file-missing 
  (message "Note: efrit-tools not found during compilation.
@@ -89,6 +90,7 @@ This is expected if you're byte-compiling standalone files.")))
 (declare-function project-roots "project" (project))
 (declare-function efrit-tools-get-context "efrit-tools" ())
 (declare-function efrit-tools-eval-sexp "efrit-tools" (sexp-string))
+(declare-function efrit--build-headers "efrit-chat" (api-key))
 
 ;;; Customization Options
 
@@ -337,11 +339,7 @@ returns appropriate error messages if the API call fails."
                            (temperature . ,(or temperature 0.0))
                            (messages . ,messages-json)))
            (url-request-method "POST")
-           (url-request-extra-headers
-            `(("x-api-key" . ,api-key)
-              ("anthropic-version" . "2023-06-01")
-              ("anthropic-beta" . "max-tokens-3-5-sonnet-2024-07-15")
-              ("content-type" . "application/json")))
+           (url-request-extra-headers (efrit--build-headers api-key))
            (url-request-data 
             (encode-coding-string (json-encode request-data) 'utf-8)))
       

--- a/efrit-chat.el
+++ b/efrit-chat.el
@@ -73,6 +73,20 @@ or 4096 without. This setting uses the higher limit."
   :type 'boolean
   :group 'efrit)
 
+(defcustom efrit-custom-headers nil
+  "Alist of custom headers to add to API requests.
+Each element should be a cons cell of (HEADER-NAME . HEADER-VALUE).
+Example: \='((\"authorization\" . \"Bearer your-token\")
+           (\"custom-header\" . \"custom-value\"))"
+  :type '(alist :key-type string :value-type string)
+  :group 'efrit)
+
+(defcustom efrit-excluded-headers nil
+  "List of default header names to exclude from API requests.
+Example: \='(\"anthropic-version\" \"anthropic-beta\")"
+  :type '(repeat string)
+  :group 'efrit)
+
 ;;; Internal variables
 
 (defvar-local efrit--message-history nil
@@ -211,17 +225,30 @@ or 4096 without. This setting uses the higher limit."
       ;; Ensure buffer is editable
       (setq buffer-read-only nil))))
 
+;;; Header customization
+
+(defun efrit--build-headers (api-key)
+  "Build HTTP headers for API requests, respecting customization options."
+  (let ((default-headers `(("x-api-key" . ,api-key)
+                          ("anthropic-version" . "2023-06-01")
+                          ("anthropic-beta" . "max-tokens-3-5-sonnet-2024-07-15")
+                          ("content-type" . "application/json"))))
+    ;; Remove excluded headers
+    (when efrit-excluded-headers
+      (setq default-headers
+            (cl-remove-if (lambda (header)
+                           (member (car header) efrit-excluded-headers))
+                         default-headers)))
+    ;; Add custom headers (custom headers override defaults)
+    (append efrit-custom-headers default-headers)))
+
 ;;; API functions
 
 (defun efrit--send-api-request (messages)
   "Send MESSAGES to the Claude API and handle the response."
   (let* ((api-key (efrit--get-api-key))
          (url-request-method "POST")
-         (url-request-extra-headers
-          `(("x-api-key" . ,api-key)
-            ("anthropic-version" . "2023-06-01")
-            ("anthropic-beta" . "max-tokens-3-5-sonnet-2024-07-15")
-            ("content-type" . "application/json")))
+         (url-request-extra-headers (efrit--build-headers api-key))
          (system-prompt (when efrit-enable-tools (efrit-tools-system-prompt)))
          (request-data
          `(("model" . ,efrit-model)

--- a/efrit-do.el
+++ b/efrit-do.el
@@ -335,10 +335,7 @@ Uses improved error handling."
   (condition-case api-err
       (let* ((api-key (efrit--get-api-key))
              (url-request-method "POST")
-             (url-request-extra-headers
-              `(("x-api-key" . ,api-key)
-                ("anthropic-version" . "2023-06-01")
-                ("content-type" . "application/json")))
+             (url-request-extra-headers (efrit--build-headers api-key))
              (system-prompt (efrit-do--command-system-prompt))
              (request-data
               `(("model" . ,efrit-model)


### PR DESCRIPTION
fixes #1 

I didn't pull out the default headers into a variable but could.

tested with the following
```
  (use-package efrit
    :vc (:url "https://github.com/tzz/efrit"
              :rev :newest)
    :custom
    (efrit-excluded-headers '("anthropic-version" "anthropic-beta"))
    (efrit-custom-headers `(("authorization" . ,(format "Bearer %s" my-litellm-bearer-token))))

    (efrit-api-url "https://my-litellm-url/v1/messages")
    (efrit-model "my-model")
    )
```