### PR TITLE
Draft: feature/use-package-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,37 @@ Efrit provides multiple interfaces for AI-powered Emacs development:
 
 4. **Restart Emacs** and test with `M-x efrit-chat`
 
+### Use with use-package + straight.el
+
+Efrit is structured for lazy loading with `use-package`. Example setup using a local checkout and a custom data directory:
+
+```elisp
+(use-package efrit
+  :straight (:type git :host github :repo "steveyegge/efrit" :files ("lisp/*.el"))
+  :init
+  ;; Set data directory before loading to avoid side effects
+  (setq efrit-data-directory (expand-file-name "~/efrit-data"))
+  ;; Optional: disable auto-initialize to control when directories are created
+  ;; (setq efrit-auto-initialize nil)
+  :commands (efrit-chat efrit efrit-do efrit-agent-run
+             efrit-remote-queue-start efrit-remote-queue-status)
+  :config
+  ;; Bind a convenient prefix (optional)
+  (setq efrit-enable-global-keymap t)
+  (efrit-setup-keybindings))
+```
+
+Or, if you vendored Efrit locally:
+
+```elisp
+(add-to-list 'load-path (expand-file-name "~/repos/3p/efrit/lisp"))
+(setq efrit-data-directory (expand-file-name "~/efrit-data"))
+(require 'efrit)
+;; Optional keybindings
+;; (setq efrit-enable-global-keymap t)
+;; (efrit-setup-keybindings)
+```
+
 ### Data Directory
 
 Efrit organizes all user data under a single configurable directory (default: `~/.emacs.d/.efrit/`):

--- a/lisp/efrit-autonomous-startup.el
+++ b/lisp/efrit-autonomous-startup.el
@@ -30,6 +30,9 @@
 (declare-function efrit-remote-queue-start "efrit-remote-queue")
 (declare-function efrit-remote-queue-stop "efrit-remote-queue")
 (declare-function efrit-remote-queue-status "efrit-remote-queue")
+;; Compile-time visibility for efrit-config helpers used below
+(declare-function efrit-config-workspace-dir "efrit-config")
+(declare-function efrit-config-data-file "efrit-config")
 
 (require 'package)
 
@@ -44,12 +47,7 @@
 (defvar efrit-autonomous-work-dir nil
   "Working directory for autonomous AI development.")
 
-;; Create workspace if it doesn't exist
-(unless (file-directory-p efrit-autonomous-work-dir)
-  (make-directory efrit-autonomous-work-dir t))
-
-;; Set default directory to workspace
-(setq default-directory efrit-autonomous-work-dir)
+;; Note: workspace dir is initialized after efrit-config is loaded below.
 
 ;; Disable unnecessary UI elements for daemon mode
 (when (fboundp 'menu-bar-mode) (menu-bar-mode -1))
@@ -81,6 +79,11 @@
       ;; Initialize directories after config is loaded
       (setq efrit-autonomous-work-dir (efrit-config-workspace-dir))
       (setq efrit-autonomous-queue-dir (efrit-config-data-file "queue-ai"))
+      ;; Ensure workspace exists now that the path is known
+      (unless (file-directory-p efrit-autonomous-work-dir)
+        (make-directory efrit-autonomous-work-dir t))
+      ;; Set default directory to workspace
+      (setq default-directory efrit-autonomous-work-dir)
       (message "Efrit Autonomous: Using workspace %s" efrit-autonomous-work-dir)
       (message "Efrit Autonomous: Using queue %s" efrit-autonomous-queue-dir)
       (require 'efrit-tools)

--- a/lisp/efrit-config.el
+++ b/lisp/efrit-config.el
@@ -32,6 +32,14 @@ The directory will be created automatically if it doesn't exist."
   :set (lambda (symbol value)
          (set-default symbol (expand-file-name value))))
 
+;; Control whether configuration auto-initializes on load.
+;; Default is t for backward compatibility; users of use-package can set
+;; this to nil in :init to avoid side effects during load.
+(defcustom efrit-auto-initialize t
+  "Whether Efrit should initialize data directories automatically on load."
+  :type 'boolean
+  :group 'efrit)
+
 ;;; Directory Management
 
 (defun efrit-config--ensure-directories ()
@@ -104,8 +112,9 @@ This is called automatically when the data directory is initialized."
   (efrit-config--ensure-directories)
   (efrit-config-migrate-old-files))
 
-;; Initialize on load
-(efrit-config-initialize)
+;; Initialize on load only if enabled (default t for backward compatibility)
+(when efrit-auto-initialize
+  (efrit-config-initialize))
 
 (provide 'efrit-config)
 


### PR DESCRIPTION
- autonomous-startup: declare efrit-config funcs for native-comp; fix init order for workspace dir/default-directory
- Make Efrit use-package friendly: minimize load-time side effects, add optional global keybinding, and add use-package/straight examples in README.