### PR TITLE
Replace 'genuinely stuck' with less ambiguous verbiage relevant to an agent

### DIFF
--- a/plans/AUTONOMOUS_MODE_DESIGN.md
+++ b/plans/AUTONOMOUS_MODE_DESIGN.md
@@ -5,7 +5,7 @@
 1. **Self-Aware via LLM** - Efrit knows it's an agent, tracks its own state, delegates reasoning to backend LLM
 2. **Signal-Based Protocol** - Client decodes LLM signals (TODO updates, action types, completion status)
 3. **Model-Agnostic Backend** - Can switch between Claude, GPT, local models
-4. **Aggressive Autonomy** - Only stops when succeeded or genuinely stuck needing user input
+4. **Aggressive Autonomy** - Only stops when succeeded or when execution cannot proceed due to unrecoverable errors or needing user input
 5. **TODO-Driven Progress** - Maintains detailed markdown plans, updated before/after every action
 
 ## Mode Hierarchy


### PR DESCRIPTION
### PR Description

**Summary**  
This PR updates the wording in the autonomy levels documentation for improved clarity and precision. Specifically, the phrase *"genuinely stuck"* has been replaced with language that more accurately reflects agent execution states.  

**Change Details**
- Original line: ```4. **Aggressive Autonomy** - Only stops when succeeded or genuinely stuck needing user input```
- Updated level 4 description to:  
  > **Aggressive Autonomy** – Only stops when succeeded or when execution cannot proceed due to unrecoverable errors or needing user input.  

**Rationale**  
The previous phrase *"genuinely stuck"* was ambiguous and anthropomorphic, which could cause confusion. The new phrasing aligns better with agent behavior and failure modes by describing two explicit termination conditions:  
- **Unrecoverable errors**: indicating execution cannot proceed due to fatal or unresolvable issues.  
- **Needing user input**: indicating the agent requires external information before it can continue.
- **Cosine similarity search reasoning**: Although I have not scored it myself, I am willing to bet that a cosine similarity search between `when execution cannot proceed due to unrecoverable errors` is closer to your intent than what `genuinely stuck` will resolve to within the models weights.

**Impact**  
- Improves clarity in documentation for developers and users interacting with agent autonomy modes.  
- Removes ambiguous language, replacing it with terminology grounded in execution and error-handling semantics.