### PR TITLE
Add flexible authentication and base URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,38 @@ Efrit provides multiple interfaces for AI-powered Emacs development:
 
 4. **Restart Emacs** and test with `M-x efrit-chat`
 
+### Advanced Configuration
+
+**Enterprise/Proxy Setup** - Configure custom API endpoints:
+
+```elisp
+;; Static base URL
+(setq efrit-api-base-url "https://proxy.company.com/anthropic")
+
+;; Dynamic base URL (function)
+(setq efrit-api-base-url 
+  (lambda () 
+    (if (company-vpn-connected-p)
+        "https://internal-proxy.company.com/anthropic"
+      "https://api.anthropic.com")))
+
+;; Custom authentication
+(setq efrit-api-key 'COMPANY_ANTHROPIC_KEY)  ; Use env variable
+```
+
+**Alternative Authentication Methods**:
+
+```elisp
+;; Environment variable (recommended)
+(setq efrit-api-key 'ANTHROPIC_API_KEY)
+
+;; Custom function
+(setq efrit-api-key (lambda () (get-secret-from-vault "anthropic-key")))
+
+;; Direct string (NOT recommended - security risk)
+(setq efrit-api-key "sk-your-key-here")
+```
+
 ### Data Directory
 
 Efrit organizes all user data under a single configurable directory (default: `~/.emacs.d/.efrit/`):

--- a/lisp/efrit-async.el
+++ b/lisp/efrit-async.el
@@ -292,7 +292,7 @@ CALLBACK is called with the parsed response or error information."
              (start-time (float-time)))
         
         (url-retrieve
-         efrit-common-api-url
+         (efrit-common-get-api-url)
          (lambda (status)
            (let ((elapsed (- (float-time) start-time)))
              (efrit-performance-record-api-time elapsed)

--- a/lisp/efrit-chat-streamlined.el
+++ b/lisp/efrit-chat-streamlined.el
@@ -55,9 +55,12 @@
   :type 'float
   :group 'efrit)
 
-(defcustom efrit-api-url "https://api.anthropic.com/v1/messages"
-  "URL for the Anthropic API endpoint."
-  :type 'string
+;; Use centralized API URL - legacy variable kept for compatibility
+(defcustom efrit-api-url nil
+  "Legacy API URL setting. Use efrit-api-base-url in efrit-common instead.
+When nil, uses the centralized configuration."
+  :type '(choice (const :tag "Use centralized config" nil)
+                 (string :tag "Legacy URL override"))
   :group 'efrit)
 
 (defcustom efrit-enable-tools t
@@ -210,7 +213,7 @@
              (if efrit-enable-tools "tools" "no tools")))
     
     ;; Send request
-    (url-retrieve efrit-api-url 'efrit-streamlined--handle-response nil t t)))
+    (url-retrieve (or efrit-api-url (efrit-common-get-api-url)) 'efrit-streamlined--handle-response nil t t)))
 
 ;;; Response Handler
 

--- a/lisp/efrit-chat.el
+++ b/lisp/efrit-chat.el
@@ -65,9 +65,12 @@ or 4096 without. This setting uses the higher limit."
   :type 'float
   :group 'efrit)
 
-(defcustom efrit-api-url "https://api.anthropic.com/v1/messages"
-  "URL for the Anthropic API endpoint."
-  :type 'string
+;; Use centralized API URL - legacy variable kept for compatibility
+(defcustom efrit-api-url nil
+  "Legacy API URL setting. Use efrit-api-base-url in efrit-common instead.
+When nil, uses the centralized configuration."
+  :type '(choice (const :tag "Use centralized config" nil)
+                 (string :tag "Legacy URL override"))
   :group 'efrit)
 
 (defcustom efrit-enable-tools t
@@ -305,7 +308,7 @@ Example: \='(\"anthropic-version\" \"anthropic-beta\")"
          (url-request-data
           (encode-coding-string (json-encode request-data) 'utf-8)))
     ;; Send request
-    (url-retrieve efrit-api-url 'efrit--handle-api-response nil t t)))
+    (url-retrieve (or efrit-api-url (efrit-common-get-api-url)) 'efrit--handle-api-response nil t t)))
 
 (defun efrit--process-http-status (status)
   "Process HTTP status and return non-nil if there's an error.

--- a/lisp/efrit-common.el
+++ b/lisp/efrit-common.el
@@ -38,6 +38,16 @@ This can be:
                  (function :tag "Function returning API key"))
   :group 'efrit)
 
+(defcustom efrit-api-base-url "https://api.anthropic.com"
+  "Base URL for Anthropic API endpoints.
+This can be:
+- A string: Static base URL (default)
+- A function: Dynamic base URL (for enterprise/proxy setups)
+Useful for corporate proxies or alternative API endpoints."
+  :type '(choice (string :tag "Static base URL")
+                 (function :tag "Function returning base URL"))
+  :group 'efrit)
+
 (defcustom efrit-api-auth-source-host "api.anthropic.com"
   "Host to use for auth-source lookup of API key."
   :type 'string
@@ -159,8 +169,17 @@ Validates key format and throws error if not found."
       (efrit-common--validate-api-key key)
       key)))
 
-(defconst efrit-common-api-url "https://api.anthropic.com/v1/messages"
-  "Anthropic API endpoint for all efrit modules.")
+(defun efrit-common-get-base-url ()
+  "Get the configured base URL for API endpoints.
+Handles both static strings and dynamic functions."
+  (cond
+   ((stringp efrit-api-base-url) efrit-api-base-url)
+   ((functionp efrit-api-base-url) (funcall efrit-api-base-url))
+   (t "https://api.anthropic.com")))
+
+(defun efrit-common-get-api-url ()
+  "Get the full API URL for messages endpoint."
+  (concat (efrit-common-get-base-url) "/v1/messages"))
 
 (defconst efrit-common-api-version "2023-06-01" 
   "Anthropic API version for all requests.")

--- a/lisp/efrit-do.el
+++ b/lisp/efrit-do.el
@@ -102,9 +102,12 @@ This affects both `efrit-do-show-todos' and `efrit-async-show-todos'."
   :type 'integer
   :group 'efrit-do)
 
-(defcustom efrit-api-url "https://api.anthropic.com/v1/messages"
-  "URL for the Anthropic API endpoint used by efrit-do."
-  :type 'string
+;; Use centralized API URL - legacy variable kept for compatibility
+(defcustom efrit-api-url nil
+  "Legacy API URL setting. Use efrit-api-base-url in efrit-common instead.
+When nil, uses the centralized configuration."
+  :type '(choice (const :tag "Use centralized config" nil)
+                 (string :tag "Legacy URL override"))
   :group 'efrit-do)
 
 ;;; Internal variables
@@ -1386,7 +1389,8 @@ attempt with ERROR-MSG and PREVIOUS-CODE from the failed attempt."
               (escaped-json (efrit-common-escape-json-unicode json-string))
               (url-request-data (encode-coding-string escaped-json 'utf-8)))
         
-        (if-let* ((response-buffer (url-retrieve-synchronously efrit-api-url))
+        (if-let* ((api-url (or efrit-api-url (efrit-common-get-api-url)))
+                  (response-buffer (url-retrieve-synchronously api-url))
                   (response-text (efrit-do--extract-response-text response-buffer)))
             (efrit-do--process-api-response response-text)
           (error "Failed to get response from API")))

--- a/lisp/efrit-multi-turn.el
+++ b/lisp/efrit-multi-turn.el
@@ -189,7 +189,7 @@ REASON: [brief explanation]"
     (efrit-log-debug "Sending completion check to Claude...")
     (condition-case err
         (with-current-buffer 
-            (url-retrieve-synchronously "https://api.anthropic.com/v1/messages" t nil efrit-multi-turn-api-timeout)
+            (url-retrieve-synchronously (efrit-common-get-api-url) t nil efrit-multi-turn-api-timeout)
           (goto-char (point-min))
           (re-search-forward "\n\n" nil t) ; Skip headers
           (let* ((response-json (buffer-substring (point) (point-max)))

--- a/lisp/efrit-protocol.el
+++ b/lisp/efrit-protocol.el
@@ -114,7 +114,7 @@ Returns the parsed response data."
            ;; Suppress unused variable warnings
            (_ (list url-request-method url-request-extra-headers url-request-data))
            (response-buffer (url-retrieve-synchronously
-                            efrit-common-api-url nil t)))
+                            (efrit-common-get-api-url) nil t)))
       
       (unless response-buffer
         (error "Failed to get response from API"))

--- a/lisp/efrit-unified.el
+++ b/lisp/efrit-unified.el
@@ -74,7 +74,7 @@ Returns \\='sync or \\='async based on Claude's analysis."
              (url-request-extra-headers (efrit-common-build-headers api-key))
              (url-request-data json-data)
              (response-buffer (url-retrieve-synchronously
-                              efrit-common-api-url nil t 5))
+                              (efrit-common-get-api-url) nil t 5))
              response-data)
         
         (when response-buffer

--- a/test/test-auth-config.el
+++ b/test/test-auth-config.el
@@ -1,0 +1,105 @@
+;;; test-auth-config.el --- Tests for authentication and configuration -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 Free Software Foundation, Inc.
+
+;; Author: Steve Yegge <steve.yegge@gmail.com>
+;; Keywords: tests
+
+;;; Commentary:
+;; Test suite for authentication and base URL configuration features.
+;; Adapted from PR #9 to work with current efrit architecture.
+
+;;; Code:
+
+(add-to-list 'load-path "../lisp")
+
+(require 'ert)
+(require 'efrit-common)
+
+;; Test helper functions
+(defun test-auth-config--with-env-var (var value body-fn)
+  "Execute BODY-FN with environment variable VAR set to VALUE."
+  (let ((old-value (getenv var)))
+    (setenv var value)
+    (unwind-protect
+        (funcall body-fn)
+      (if old-value
+          (setenv var old-value)
+        (setenv var nil)))))
+
+(defmacro test-auth-config-with-env (var value &rest body)
+  "Execute BODY with environment variable VAR set to VALUE."
+  `(test-auth-config--with-env-var ,var ,value (lambda () ,@body)))
+
+;; Authentication tests
+(ert-deftest test-auth-config-env-var-symbol ()
+  "Test API key retrieval from environment variable via symbol."
+  (test-auth-config-with-env "TEST_API_KEY" "sk-test-key-1234567890abcdef"
+    (let ((efrit-api-key 'TEST_API_KEY))
+      (should (string= (efrit-common-get-api-key) "sk-test-key-1234567890abcdef")))))
+
+(ert-deftest test-auth-config-env-var-anthropic ()
+  "Test API key retrieval from ANTHROPIC_API_KEY environment variable."
+  (test-auth-config-with-env "ANTHROPIC_API_KEY" "sk-fallback-key-1234567890abcdef"
+    (let ((efrit-api-key nil))
+      (should (string= (efrit-common-get-api-key) "sk-fallback-key-1234567890abcdef")))))
+
+(ert-deftest test-auth-config-function ()
+  "Test API key retrieval from function."
+  (let ((efrit-api-key (lambda () "sk-function-key-1234567890abcdef")))
+    (should (string= (efrit-common-get-api-key) "sk-function-key-1234567890abcdef"))))
+
+(ert-deftest test-auth-config-invalid-key-format ()
+  "Test that invalid API key formats are rejected."
+  (let ((efrit-api-key "invalid-key"))
+    (should-error (efrit-common-get-api-key) :type 'error)))
+
+(ert-deftest test-auth-config-empty-key ()
+  "Test that empty API keys are rejected."
+  (let ((efrit-api-key ""))
+    (should-error (efrit-common-get-api-key) :type 'error)))
+
+;; Base URL configuration tests
+(ert-deftest test-auth-config-base-url-string ()
+  "Test static base URL configuration."
+  (let ((efrit-api-base-url "https://custom-api.example.com"))
+    (should (string= (efrit-common-get-base-url) "https://custom-api.example.com"))
+    (should (string= (efrit-common-get-api-url) "https://custom-api.example.com/v1/messages"))))
+
+(ert-deftest test-auth-config-base-url-function ()
+  "Test dynamic base URL configuration."
+  (let ((efrit-api-base-url (lambda () "https://dynamic-api.example.com")))
+    (should (string= (efrit-common-get-base-url) "https://dynamic-api.example.com"))
+    (should (string= (efrit-common-get-api-url) "https://dynamic-api.example.com/v1/messages"))))
+
+(ert-deftest test-auth-config-base-url-default ()
+  "Test default base URL configuration."
+  (let ((efrit-api-base-url nil))
+    (should (string= (efrit-common-get-base-url) "https://api.anthropic.com"))
+    (should (string= (efrit-common-get-api-url) "https://api.anthropic.com/v1/messages"))))
+
+;; Security tests
+(ert-deftest test-auth-config-key-sanitization ()
+  "Test that API keys are sanitized in logs."
+  (let ((test-key "sk-test-very-long-key-1234567890abcdef"))
+    (should (string= (efrit-common--sanitize-key-for-logging test-key) "sk-tes...cdef"))))
+
+(ert-deftest test-auth-config-key-validation ()
+  "Test API key validation function."
+  (should (efrit-common--validate-api-key "sk-valid-key-1234567890abcdef"))
+  (should-error (efrit-common--validate-api-key "invalid") :type 'error)
+  (should-error (efrit-common--validate-api-key "sk-short") :type 'error)
+  (should-error (efrit-common--validate-api-key "") :type 'error)
+  (should-error (efrit-common--validate-api-key nil) :type 'error))
+
+;; Integration test
+(ert-deftest test-auth-config-full-integration ()
+  "Test full authentication and URL configuration integration."
+  (test-auth-config-with-env "CUSTOM_API_KEY" "sk-integration-key-1234567890abcdef"
+    (let ((efrit-api-key 'CUSTOM_API_KEY)
+          (efrit-api-base-url "https://enterprise.example.com"))
+      (should (string= (efrit-common-get-api-key) "sk-integration-key-1234567890abcdef"))
+      (should (string= (efrit-common-get-api-url) "https://enterprise.example.com/v1/messages")))))
+
+(provide 'test-auth-config)
+;;; test-auth-config.el ends here


### PR DESCRIPTION
Inspired by PR #9, this adds enterprise-ready configuration options while preserving the existing auth system architecture.

## What's New

**🔧 Flexible Base URL Configuration:**
- Static base URL configuration: `efrit-api-base-url`
- Dynamic base URL support via functions (for proxy/VPN switching)
- Centralized URL management across all modules

**🔒 Enhanced Authentication Options:**
- Environment variable authentication (recommended)
- Custom authentication functions (vault integration)
- Maintains existing auth-source support
- Backward compatibility with legacy configurations

**✅ Comprehensive Testing:**
- 11 test cases covering authentication scenarios
- Base URL configuration testing
- Security validation and key sanitization tests

**📚 Updated Documentation:**
- Enterprise setup examples
- Proxy configuration patterns
- Security best practices

## Technical Details

- All modules now use centralized `efrit-common-get-api-url()`
- Legacy `efrit-api-url` variables preserved for compatibility
- Clean compilation, all tests passing
- Follows existing security patterns

## Enterprise Use Cases

```elisp
;; Corporate proxy setup
(setq efrit-api-base-url "https://proxy.company.com/anthropic")

;; Dynamic proxy switching
(setq efrit-api-base-url
  (lambda ()
    (if (company-vpn-connected-p)
        "https://internal-proxy.company.com/anthropic"
      "https://api.anthropic.com")))

;; Environment variable auth
(setq efrit-api-key 'COMPANY_ANTHROPIC_KEY)
```

Addresses the core configuration flexibility requested in PR #9 while working seamlessly with the current codebase.

Amp-Thread-ID: https://ampcode.com/threads/T-e9919593-c8da-40cd-a27c-29f8b38b4f1a