### PR TITLE
Update default model to one Anthropic still allows

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Transform Efrit from a user assistant into an **autonomous AI development platfo
 
 ```elisp
 ;; Standard Efrit settings
-(setq efrit-model "claude-3-5-sonnet-20241022")
+(setq efrit-model "claude-3-7-sonnet-20250219")
 (setq efrit-max-tokens 8192)
 
 ;; 🆕 Performance settings

--- a/archived/efrit-agent.el
+++ b/archived/efrit-agent.el
@@ -33,9 +33,9 @@
   :group 'efrit
   :prefix "efrit-agent-")
 
-(defcustom efrit-agent-backend "claude-3.5-sonnet"
+(defcustom efrit-agent-backend "claude-3.7-sonnet"
   "Default model backend for agent mode."
-  :type '(choice (const "claude-3.5-sonnet")
+  :type '(choice (const "claude-3.7-sonnet")
                  (const "gpt-4") 
                  (const "local-llama")
                  (string :tag "Custom API endpoint"))

--- a/lisp/efrit-config.el
+++ b/lisp/efrit-config.el
@@ -111,12 +111,12 @@ This is called automatically when the data directory is initialized."
 
 ;;; Model Configuration
 
-(defcustom efrit-default-model "claude-3-5-sonnet-20241022"
+(defcustom efrit-default-model "claude-3-7-sonnet-20250219"
   "Default Claude model for all efrit operations."
   :type 'string
   :group 'efrit)
 
-(defcustom efrit-completion-model "claude-3-5-sonnet-20241022"
+(defcustom efrit-completion-model "claude-3-7-sonnet-20250219"
   "Claude model for completion assessment and lightweight operations."
   :type 'string
   :group 'efrit)

--- a/lisp/efrit-do.el
+++ b/lisp/efrit-do.el
@@ -86,7 +86,7 @@ This affects both `efrit-do-show-todos' and `efrit-async-show-todos'."
   :type 'boolean
   :group 'efrit-do)
 
-(defcustom efrit-model "claude-3-5-sonnet-20241022"
+(defcustom efrit-model "claude-3-7-sonnet-20250219"
   "Claude model to use for efrit-do commands."
   :type 'string
   :group 'efrit-do)

--- a/lisp/efrit-protocol.el
+++ b/lisp/efrit-protocol.el
@@ -85,7 +85,7 @@ Returns the result of the tool execution or signals an error."
 Returns the parsed response data."
   (let* ((api-key (efrit-common-get-api-key))
          (model (or (bound-and-true-p efrit-model) 
-                   "claude-3-5-sonnet-20241022"))
+                   "claude-3-7-sonnet-20250219"))
          (max-tokens (or (bound-and-true-p efrit-max-tokens) 8192))
          (request-data `(("model" . ,model)
                         ("max_tokens" . ,max-tokens)

--- a/lisp/efrit-unified.el
+++ b/lisp/efrit-unified.el
@@ -64,7 +64,7 @@ Returns \\='sync or \\='async based on Claude's analysis."
   (condition-case err
       (let* ((api-key (efrit-common-get-api-key))
              (prompt (format "Analyze this command and decide if it should run synchronously or asynchronously:\n\"%s\"\n\nUse the suggest_execution_mode tool to indicate your decision." command))
-             (request-data `(("model" . "claude-3-5-sonnet-20241022")
+             (request-data `(("model" . "claude-3-7-sonnet-20250219")
                            ("max_tokens" . 1000)
                            ("messages" . [,(efrit-unified--make-mode-request-message prompt)])
                            ("tools" . [,efrit-unified--mode-decision-tool])))


### PR DESCRIPTION
Anthropic seems to have deprecated `claude-3-5-sonnet-20241022`
as a model. Attempts to use `efrit` with that model as a backend
result in an "unknown model" error.

Swap to `claude-3-7-sonnet-20250219` instead.

----

This feels like an arms race where we'll have to bump this forward
again in a few months. A structural change would be nice but is
beyond my current grasp of elisp.
