### PR TITLE
Fix spinner animation errors

### DIFF
--- a/lisp/support/efrit-spinner.el
+++ b/lisp/support/efrit-spinner.el
@@ -23,9 +23,9 @@
 
 ;;; Customization
 
-(defcustom efrit-spinner-frames '("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
+(defcustom efrit-spinner-frames ["⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏"]
   "Spinner animation frames to cycle through."
-  :type '(repeat string)
+  :type '(vector string)
   :group 'efrit)
 
 (defcustom efrit-spinner-interval 0.08
@@ -112,8 +112,9 @@
             (goto-char (marker-position efrit-spinner--spinner-marker))
             ;; Move back to the start of "System: "
             (beginning-of-line)
-            ;; Delete the entire line
-            (delete-region (point) (+ (point) (length "System: Thinking X\n")))))
+            ;; Delete the entire line safely
+            (let ((end (line-end-position)))
+              (delete-region (point) (if (< end (point-max)) (1+ end) end)))))
         (setq-local efrit-spinner--spinner-marker nil)
         (setq-local efrit-spinner--frame-index 0)))))
 


### PR DESCRIPTION
Fixed "Wrong type argument: arrayp" error reported in https://github.com/steveyegge/efrit/issues/25:
- Changed spinner frames from list to vector to work with `aref`.

Also fixed "Args out of range" error in deletion logic that was masked by the arrayp issue:
- Replaced hardcoded length calculation with safe bounds-checked deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)