### PR TITLE
Respect user-emacs-directory for Efrit data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ coverage: compile
 		--eval "(efrit-coverage-report)" \
 		--eval "(efrit-coverage-report-lcov)" \
 		--eval "(efrit-coverage-report-json)"
-	@echo "✅ Coverage report generated in ~/.emacs.d/.efrit/coverage/"
+	@echo "✅ Coverage report generated in user-emacs-directory/.efrit/coverage/"
 
 coverage-simple: compile
 	@echo "Running simple function-level coverage..."

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ The async API is now recommended for all use cases. Use `efrit-do-sync` only if 
 (setq efrit-max-tokens 8192)
 
 ;; Data directory
-(setq efrit-data-directory "~/.emacs.d/.efrit/")
+(setq efrit-data-directory (expand-file-name ".efrit" user-emacs-directory))
 
 ;; Enable debug logging
 (setq efrit-log-level 'debug)
@@ -405,7 +405,7 @@ The default forbidden patterns block truly dangerous commands like `sudo`, `shut
 
 ## Data Directory
 
-All data lives under `~/.emacs.d/.efrit/`:
+By default, all data lives under `.efrit/` inside `user-emacs-directory`:
 
 ```
 .efrit/

--- a/lisp/core/efrit-config.el
+++ b/lisp/core/efrit-config.el
@@ -30,7 +30,11 @@ Update this when releasing new versions.")
   :group 'applications
   :prefix "efrit-")
 
-(defcustom efrit-data-directory "~/.emacs.d/.efrit"
+(defun efrit-config-default-data-directory ()
+  "Return Efrit's default data directory."
+  (expand-file-name ".efrit" user-emacs-directory))
+
+(defcustom efrit-data-directory (efrit-config-default-data-directory)
   "Directory for storing efrit data files.
 This includes context files, session data, communication queues, logs,
 and cache. The directory will be created automatically if it doesn't exist."

--- a/lisp/core/efrit-tool-utils.el
+++ b/lisp/core/efrit-tool-utils.el
@@ -32,6 +32,7 @@
 (require 'json)
 (require 'cl-lib)
 (require 'url-parse)
+(require 'efrit-config)
 
 ;;; Customization
 
@@ -504,7 +505,8 @@ The file path is determined by `efrit-tool-audit-file'."
   :type 'boolean
   :group 'efrit-tool-utils)
 
-(defcustom efrit-tool-audit-file "~/.emacs.d/.efrit/logs/tool-audit.log"
+(defcustom efrit-tool-audit-file
+  (expand-file-name "logs/tool-audit.log" efrit-data-directory)
   "File path for tool audit log when `efrit-tool-audit-to-file' is non-nil."
   :type 'file
   :group 'efrit-tool-utils)

--- a/lisp/interfaces/efrit-session-history.el
+++ b/lisp/interfaces/efrit-session-history.el
@@ -17,7 +17,7 @@
 ;; - Session replay (show progress buffer from past session)
 ;; - Cleanup of old sessions with configurable retention policy
 ;;
-;; Sessions are stored in ~/.emacs.d/.efrit/sessions/ with metadata.
+;; Sessions are stored in the Efrit data directory with metadata.
 
 ;;; Code:
 

--- a/lisp/support/efrit-ui.el
+++ b/lisp/support/efrit-ui.el
@@ -27,7 +27,7 @@
 (require 'efrit-ui-dashboard)
 (require 'efrit-ui-todos)
 
-(defvar efrit-data-directory (expand-file-name "~/.emacs.d/.efrit/")
+(defvar efrit-data-directory (expand-file-name ".efrit" user-emacs-directory)
   "Directory for efrit data storage.")
 
 ;;; Initialization

--- a/lisp/tools/efrit-tool-checkpoint.el
+++ b/lisp/tools/efrit-tool-checkpoint.el
@@ -27,7 +27,8 @@
 
 ;;; Customization
 
-(defcustom efrit-checkpoint-dir "~/.emacs.d/.efrit/checkpoints/"
+(defcustom efrit-checkpoint-dir
+  (expand-file-name "checkpoints" efrit-data-directory)
   "Directory to store checkpoint metadata."
   :type 'directory
   :group 'efrit-tool-utils)

--- a/lisp/tools/efrit-tool-confirm-action.el
+++ b/lisp/tools/efrit-tool-confirm-action.el
@@ -36,7 +36,8 @@
   :type 'integer
   :group 'efrit-tool-utils)
 
-(defcustom efrit-confirm-log-file "~/.emacs.d/.efrit/logs/confirmations.log"
+(defcustom efrit-confirm-log-file
+  (expand-file-name "logs/confirmations.log" efrit-data-directory)
   "File path for confirmation audit log."
   :type 'file
   :group 'efrit-tool-utils)

--- a/lisp/tools/efrit-tool-undo-edit.el
+++ b/lisp/tools/efrit-tool-undo-edit.el
@@ -29,7 +29,8 @@
 
 ;;; Undo Registry Management
 
-(defcustom efrit-undo-edit-dir "~/.emacs.d/.efrit/undo/"
+(defcustom efrit-undo-edit-dir
+  (expand-file-name "undo" efrit-data-directory)
   "Directory to store per-file undo history."
   :type 'directory
   :group 'efrit-tool-utils)

--- a/test/efrit-coverage.el
+++ b/test/efrit-coverage.el
@@ -60,7 +60,7 @@ Set to 0 to disable threshold checking."
 
 (defcustom efrit-coverage-output-dir nil
   "Directory for coverage reports.
-If nil, uses ~/.emacs.d/.efrit/coverage/."
+If nil, uses .efrit/coverage/ under `user-emacs-directory'."
   :type '(choice (const nil) directory)
   :group 'efrit-coverage)
 
@@ -99,7 +99,7 @@ Each entry is an alist with:
   "Return the coverage output directory, creating it if needed."
   (let ((dir (or efrit-coverage-output-dir
                  (expand-file-name "coverage"
-                                   (expand-file-name ".efrit" "~/.emacs.d")))))
+                                   (expand-file-name ".efrit" user-emacs-directory)))))
     (unless (file-directory-p dir)
       (make-directory dir t))
     dir))

--- a/test/efrit-test-runner.el
+++ b/test/efrit-test-runner.el
@@ -59,7 +59,7 @@
   :group 'efrit-test-runner)
 
 (defcustom efrit-test-results-dir nil
-  "Directory for test results. If nil, uses ~/.emacs.d/.efrit/test-results/."
+  "Directory for test results. If nil, uses .efrit/test-results/ under `user-emacs-directory'."
   :type '(choice (const nil) directory)
   :group 'efrit-test-runner)
 

--- a/test/test-efrit-config.el
+++ b/test/test-efrit-config.el
@@ -144,6 +144,12 @@
 
 ;;; Path Expansion Tests
 
+(ert-deftest test-config-default-data-directory-uses-user-emacs-directory ()
+  "Test that the default data directory follows `user-emacs-directory'."
+  (let ((user-emacs-directory "/tmp/efrit-custom-emacs.d/"))
+    (should (equal (efrit-config-default-data-directory)
+                   "/tmp/efrit-custom-emacs.d/.efrit"))))
+
 (ert-deftest test-config-data-directory-expansion ()
   "Test that data directory handles tilde expansion."
   (let ((efrit-data-directory "~/test-efrit"))


### PR DESCRIPTION
I believe this is a better canonical approach. Customising `efrit-data-directory` was not causing a few other variables to update. And if `.emacs.d` gets created, next launch of emacs (omg) will read `.emacs.d` instead of say `.config/emacs`.

Addresses issue #30 